### PR TITLE
initialize variable

### DIFF
--- a/scripts/ipfire_services.pl
+++ b/scripts/ipfire_services.pl
@@ -160,7 +160,7 @@ sub addonservicestats{
         my $pid = '';
         my $testcmd = '';
         my $exename;
-        my @memory;
+        my @memory = (0);
 
         $testcmd = `sudo /usr/local/bin/addonctrl $_ status 2>/dev/null`;
 
@@ -194,4 +194,3 @@ sub addonservicestats{
         }
         return $status;
 }
-


### PR DESCRIPTION
Initialize the first index of the @memory array to get rid of the warning:

`Use of uninitialized value in addition (+) at /etc/zabbix_agentd/scripts/ipfire_services.pl line 188.`