### PR TITLE
Adding DHCP client and Captive Portal client

### DIFF
--- a/template_app_ipfire_by_zabbix_agent_active.xml
+++ b/template_app_ipfire_by_zabbix_agent_active.xml
@@ -41,6 +41,9 @@ Created by Robin Roevens (robin.roevens (at) disroot.org)</description>
                 <template>
                     <name>Template Module IPFire Services by Zabbix Agent Active</name>
                 </template>
+                <template>
+                    <name>Template Module IPFire DHCP Clients by Zabbix Agent Active</name>
+                </template>
             </templates>
             <groups>
                 <group>
@@ -790,6 +793,48 @@ Created by Robin Roevens (robin.roevens (at) disroot.org)</description>
                     <description>Whether we need to trigger when a service is down. This variable can be used with context to exclude specific services.</description>
                 </macro>
             </macros>
+        </template>
+        <template>
+            <uuid>85fea82fd2be4f5fb7e0ba93e268f5a6</uuid>
+            <template>Template Module IPFire DHCP Clients by Zabbix Agent Active</template>
+            <name>Template Module IPFire DHCP Clients by Zabbix Agent Active</name>
+            <description>Monitor DHCP clients of IPFire Services
+Created by Stack Korora ( stackkorora (at) disroot.org )</description>
+            <groups>
+                <group>
+                    <name>Templates/Modules</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>437fe278f4984f42917039aff8fd6c28</uuid>
+                    <name>IPFire Captive Portal Clients</name>
+                    <type>ZABBIX_ACTIVE</type>
+                    <key>ipfire.captive.clients</key>
+                    <history>1d</history>
+                    <description>Number of active users on captive portal</description>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>IPFire Captive Portal</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>0e8d3a7d6c1a4224b388bdcbb4c31eb7</uuid>
+                    <name>IPFire DHCPd Leases</name>
+                    <type>ZABBIX_ACTIVE</type>
+                    <key>ipfire.dhcp.clients</key>
+                    <history>1d</history>
+                    <description>Number of active dhcpd leases on captive portal</description>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>IPFire DHCPd Leases</value>
+                        </tag>
+                    </tags>
+                </item>
+            </items>
         </template>
     </templates>
     <graphs>

--- a/zabbix_agentd.d/template_module_ipfire_dhcp_stats.conf
+++ b/zabbix_agentd.d/template_module_ipfire_dhcp_stats.conf
@@ -1,0 +1,2 @@
+UserParameter=ipfire.captive.clients,awk -F ',' 'length($2) == 17 {sum += 1} END {if (length(sum) == 0) print 0; else print sum}' /var/ipfire/captive/clients
+UserParameter=ipfire.dhcp.clients,grep -E 'lease|bind' /var/state/dhcp/dhcpd.leases | sed ':a;/{$/{N;s/\n//;ba}' | grep "state active" | wc -l


### PR DESCRIPTION
I needed to capture the metrics for dhcpd clients as well as those on the captive portal. I extended into a new template, but both checks are pretty simple. I don't have any need for triggers (yet), so these are just data collection.

The captive portal is a simple awk script to count leases with an active mac address.

The dhcpd is a bit messier. I opted for a chain of simpler commands then the really super narsty complex awk script I originally wrote. Grep out lease and bind, then use sed to join any line that ends with a { with the next line to make the grep for only active leases. All because I don't care about leases where the client isn't around anymore.

Both return 0 by default if there are no matches.

I exported my template from Zabbix 5.4.9.